### PR TITLE
Changed secondary loss calculation (solves #43)

### DIFF
--- a/pyfair/model/model_input.py
+++ b/pyfair/model/model_input.py
@@ -254,11 +254,8 @@ class FairDataInput(object):
                 s = pd.Series(data)
                 # Put in dict
                 df_dict[target][column] = s
-        # Multiply
-        df1, df2 = df_dict.values()
-        combined_df = df1 * df2
-        # Sum
-        summed = combined_df.sum(axis=1)
+        # Get partial secondary losses and sum up all the values
+        summed = np.sum(df.prod(axis=1) for df in df_dict.values())
         # Record params
         new_target = 'multi_' + final_target
         self._supplied_values[new_target] = kwargs_dict


### PR DESCRIPTION
In the original code losses were multiplied (instead of being added) and frequencies were added (instead of being multiplied). Now the code works as expected:

```python
model1 = pyfair.FairModel(name="Insider Threat", n_simulations=10)
model1.input_multi_data('Secondary Loss', {
    'Reputational': {
        'Secondary Loss Event Frequency': {'constant': 1},
        'Secondary Loss Event Magnitude': {'constant': 10},
    },
    'Legal': {
        'Secondary Loss Event Frequency': {'constant': 1},
        'Secondary Loss Event Magnitude': {'constant': 10},
    }
})
```
```model1._model_table["Secondary Loss"]``` returns:

```
0    20.0
1    20.0
2    20.0
3    20.0
4    20.0
5    20.0
6    20.0
7    20.0
8    20.0
9    20.0
```


```python

model2 = pyfair.FairModel(name="Insider Threat", n_simulations=10)
model2.input_multi_data('Secondary Loss', {
    'Reputational': {
        'Secondary Loss Event Frequency': {'constant': 0},
        'Secondary Loss Event Magnitude': {'constant': 10},
    },
    'Legal': {
        'Secondary Loss Event Frequency': {'constant': 0},
        'Secondary Loss Event Magnitude': {'constant': 10},
    }
})
```
```model2._model_table["Secondary Loss"]```  is equal to:

```
0    0.0
1    0.0
2    0.0
3    0.0
4    0.0
5    0.0
6    0.0
7    0.0
8    0.0
9    0.0
```

```python
model3 = pyfair.FairModel(name="Insider Threat", n_simulations=10)
model3.input_multi_data('Secondary Loss', {
    'Reputational': {
        'Secondary Loss Event Frequency': {'constant': 1},
        'Secondary Loss Event Magnitude': {'constant': 10},
    },
    'Legal': {
        'Secondary Loss Event Frequency': {'constant': 1},
        'Secondary Loss Event Magnitude': {'constant': 10},
    },
    'Response': {
        'Secondary Loss Event Frequency': {'constant': 1},
        'Secondary Loss Event Magnitude': {'constant': 10},
    }
})
```
```model3``` does not return errors anymore.
