### PR TITLE
chore: Derive-Risk metadata after org transfer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: python
-script: python ./tests/test_runner.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,13 +19,13 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'pyfair'
-copyright = '2023, Hive Systems, LLC'
-author = 'Hive Systems'
+copyright = '2023-2026, Derive Risk'
+author = 'Derive Risk'
 
 # The short X.Y version
-version = '0.1.12'
+version = '0.1.14'
 # The full version, including alpha/beta/rc tags
-release = '0.1-alpha.12'
+release = '0.1-alpha.14'
 
 
 # -- General configuration ---------------------------------------------------
@@ -137,7 +137,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'pyfair.tex', 'pyfair Documentation',
-     'Hive Systems', 'manual'),
+     'Derive Risk', 'manual'),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'pyfair'
-copyright = '2023-2026, Derive Risk'
-author = 'Derive Risk'
+copyright = '2023-2026, Quant LLC'
+author = 'Derive'
 
 # The short X.Y version
 version = '0.1.14'
@@ -137,7 +137,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'pyfair.tex', 'pyfair Documentation',
-     'Derive Risk', 'manual'),
+     'Derive', 'manual'),
 ]
 
 

--- a/pyfair/_version.py
+++ b/pyfair/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1-alpha.12"
+__version__ = "0.1-alpha.14"

--- a/pyfair/report/base_report.py
+++ b/pyfair/report/base_report.py
@@ -262,7 +262,7 @@ class FairBaseReport(object):
         risk_results = risk_results.agg(["mean", "std", "min", "max"])
         risk_results.index = ["Mean", "Stdev", "Minimum", "Maximum"]
         # Format risk results into dataframe
-        overview_df = risk_results.applymap(
+        overview_df = risk_results.map(
             lambda x: self._format_strings["Risk"].format(x)
         )
         overview_df.loc["Simulations"] = [
@@ -321,7 +321,7 @@ class FairBaseReport(object):
             # On a column basis
             axis=1,
         )
-        param_df = param_df.applymap(lambda x: "" if "nan" in x else x)
+        param_df = param_df.map(lambda x: "" if "nan" in x else x)
         # Do not truncate our base64 images.
         pd.set_option("display.max_colwidth", None)
         # Create our distribution icons as strings in table

--- a/pyfair/report/base_report.py
+++ b/pyfair/report/base_report.py
@@ -22,6 +22,14 @@ from ..model.meta_model import FairMetaModel
 from ..utility.beta_pert import FairBetaPert
 
 
+def _dataframe_elementwise(df, func):
+    """Element-wise transform; pandas 2.1+ uses map, older uses applymap."""
+    applymap = getattr(df, "applymap", None)
+    if applymap is not None:
+        return applymap(func)
+    return df.map(func)
+
+
 class FairBaseReport(object):
     """A base class for creating FairModel and FairMetaModel reports
 
@@ -262,8 +270,8 @@ class FairBaseReport(object):
         risk_results = risk_results.agg(["mean", "std", "min", "max"])
         risk_results.index = ["Mean", "Stdev", "Minimum", "Maximum"]
         # Format risk results into dataframe
-        overview_df = risk_results.map(
-            lambda x: self._format_strings["Risk"].format(x)
+        overview_df = _dataframe_elementwise(
+            risk_results, lambda x: self._format_strings["Risk"].format(x)
         )
         overview_df.loc["Simulations"] = [
             "{0:,.0f}".format(len(model.export_results()))
@@ -321,7 +329,9 @@ class FairBaseReport(object):
             # On a column basis
             axis=1,
         )
-        param_df = param_df.map(lambda x: "" if "nan" in x else x)
+        param_df = _dataframe_elementwise(
+            param_df, lambda x: "" if "nan" in x else x
+        )
         # Do not truncate our base64 images.
         pd.set_option("display.max_colwidth", None)
         # Create our distribution icons as strings in table

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=0.24.1
+pandas>=2.1.0
 numpy>=1.16.1
 scipy>=1.2.1
 matplotlib>=3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=2.1.0
+pandas>=0.24.1
 numpy>=1.16.1
 scipy>=1.2.1
 matplotlib>=3.0.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pyfair",
-    version="0.1-alpha.13",
+    version="0.1-alpha.14",
     description="Open FAIR Monte Carlo creator",
     long_description="""
         Factor Analysis of Information Risk (Open FAIR) model in Python.
@@ -18,7 +18,7 @@ setup(
         "Open FAIR" is a trademark of the Open Group.
 
     """,
-    author="Hive Systems",
+    author="Derive Risk",
     author_email="pyfair@hivesystems.com",
     packages=[
         "pyfair",
@@ -27,7 +27,7 @@ setup(
         "pyfair.utility",
     ],
     license="MIT",
-    url="https://github.com/Hive-Systems/pyfair",
+    url="https://github.com/Derive-Risk/pyfair",
     keywords=["FAIR", "risk", "monte carlo", "cyber risk", "risk analysis"],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "Open FAIR" is a trademark of the Open Group.
 
     """,
-    author="Derive Risk",
+    author="Derive",
     author_email="pyfair@hivesystems.com",
     packages=[
         "pyfair",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
 
     """,
     author="Derive",
-    author_email="pyfair@hivesystems.com",
+    author_email="pyfair@deriverisk.com",
     packages=[
         "pyfair",
         "pyfair.model",


### PR DESCRIPTION
## Summary

- Point package metadata and Sphinx docs at **Derive-Risk/pyfair**
- Align version strings to **0.1-alpha.14** (PyPI patch release follows merge + soak)
- Remove obsolete `.travis.yml`

## Post-merge (operator)

1. Merge when CI green
2. **Read the Docs:** Admin > Integrations — reconnect **Derive-Risk**; confirm clone URL `https://github.com/Derive-Risk/pyfair.git`; rebuild `latest`
3. **PyPI:** After soak (inventory checklist), add Derive maintainers, trusted publisher, publish patch with new homepage
4. Close Snyk PRs #80, #82, #83 without merge (rediscover on Derive-Risk)

## Test plan

- [ ] CI workflow passes (Python 3.8–3.12)
- [ ] CodeQL completes